### PR TITLE
Prebuilt library support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,8 @@ name = "tflitec"
 
 [build-dependencies]
 bindgen = "0.59.1"
+fs_extra = "1.2.0"
+curl = "0.4.43"
 
 [features]
 xnnpack = []

--- a/README.md
+++ b/README.md
@@ -76,12 +76,31 @@ assert_eq!(expected, output_vector);
 # Ok::<(), tflitec::Error>(())
 ```
 
+# Prebuilt Library Support
+
+As described in the [compilation section](#compilation), `libtensorflowlite_c` is built during compilation and
+this step may take a few minutes. To allow reusing prebuilt library, one can set `TFLITEC_PREBUILT_PATH` or 
+`TFLITEC_PREBUILT_PATH_<NORMALIZED_TARGET>` environment variables (the latter has precedence).
+`NORMALIZED_TARGET` is the target triple which is [converted to uppercase and underscores][triple_normalization], 
+as in the cargo configuration environment variables. Below you can find example values for different `TARGET`s:
+
+* `TFLITEC_PREBUILT_PATH_AARCH64_APPLE_IOS=/path/to/TensorFlowLiteC.framework`
+* `TFLITEC_PREBUILT_PATH_ARMV7_LINUX_ANDROIDEABI=/path/to/libtensorflowlite_c.so`
+* `TFLITEC_PREBUILT_PATH_X86_64_APPLE_DARWIN=/path/to/libtensorflowlite_c.dylib`
+* `TFLITEC_PREBUILT_PATH_X86_64_PC_WINDOWS_MSVC=/path/to/tensorflowlite_c.dll`. **Note that**, the prebuilt `.dll` 
+file must have the corresponding `.lib` file under the same directory.
+
+You can find these files under the [`OUT_DIR`][cargo documentation] after you compile the library for the first time, 
+then copy them to a persistent path and set environment variable.
+
 # Compilation
 
-Current version of the crate builds `v2.9.1` branch of [tensorflow project].
+Current version of the crate builds tag `v2.9.1` of the [tensorflow project].
 Compiled dynamic library or Framework will be available under `OUT_DIR`
 (see [cargo documentation]) of `tflitec`.
 You won't need this most of the time, because the crate output is linked appropriately.
+In addition, it may be better to read [prebuilt library support](#prebuilt-library-support) section 
+to make your builds faster.
 For all environments and targets you will need to have:
 
 * `git` CLI to fetch [TensorFlow]
@@ -118,7 +137,8 @@ BINDGEN_EXTRA_CLANG_ARGS="\
 -I${ANDROID_NDK_HOME}/sysroot/usr/include/ \
 -I${ANDROID_NDK_HOME}/toolchains/llvm/prebuilt/${HOST_TAG}/sysroot/usr/include/${TARGET_TRIPLE}/"
 ```
-* (Recommended) [cargo-ndk] simplifies `cargo build` process.
+* (Recommended) [cargo-ndk] simplifies `cargo build` process. Recent version of the tool has `--bindgen` flag
+which sets `BINDGEN_EXTRA_CLANG_ARGS` variable appropriately. Hence, you can skip the step above.
 
 ## Windows
 
@@ -147,3 +167,4 @@ Do not forget to add relevant paths to `%PATH%` environment variable by followin
 [cargo-ndk]: https://github.com/bbqsrc/cargo-ndk
 [TensorFlow Build Instructions for Windows]: https://www.tensorflow.org/install/source_windows
 [MSYS2]: https://www.msys2.org/
+[triple_normalization]: https://doc.rust-lang.org/cargo/reference/config.html#environment-variables

--- a/README.md
+++ b/README.md
@@ -78,22 +78,22 @@ assert_eq!(expected, output_vector);
 
 # Compilation
 
-Current version of the crate builds `r2.6` branch of [tensorflow project].
+Current version of the crate builds `v2.9.1` branch of [tensorflow project].
 Compiled dynamic library or Framework will be available under `OUT_DIR`
 (see [cargo documentation]) of `tflitec`.
 You won't need this most of the time, because the crate output is linked appropriately.
 For all environments and targets you will need to have:
 
 * `git` CLI to fetch [TensorFlow]
-* [Bazel] to build [TensorFlow], supported versions: `[3.7.2, 3.99.0]`
+* [Bazel] to build [TensorFlow], it is recommended to use [bazelisk].
 * Python3 to build [TensorFlow]
 
 ## Optimized Build
 To build [TensorFlow] for your machine with native optimizations
 or pass other `--copts` to [Bazel], set environment variable below:
 ```sh
-BAZEL_COPTS="OPT1 OPT2 ..." # space seperated values will be passed as `--copt=OPTN` to bazel
-BAZEL_COPTS="-march=native" # for native optimized build
+TFLITEC_BAZEL_COPTS="OPT1 OPT2 ..." # space seperated values will be passed as `--copt=OPTN` to bazel
+TFLITEC_BAZEL_COPTS="-march=native" # for native optimized build
 ```
 ---
 Some OSs or targets may require additional steps.
@@ -126,7 +126,7 @@ Windows support is experimental. It is tested on Windows 10. You should follow i
 the `Setup for Windows` section on [TensorFlow Build Instructions for Windows]. In other words,
 you should install following before build:
 * Python 3.8.x 64 bit (the instructions suggest 3.6.x but this package is tested with 3.8.x)
-* Bazel, supported versions: `[3.7.2, 3.99.0]`
+* [Bazel]
 * [MSYS2]
 * Visual C++ Build Tools 2019
 
@@ -135,6 +135,7 @@ Do not forget to add relevant paths to `%PATH%` environment variable by followin
 
 [TensorFlow]: https://www.tensorflow.org/
 [Bazel]: https://bazel.build/
+[bazelisk]: https://github.com/bazelbuild/bazelisk
 [Bindgen]: https://github.com/rust-lang/rust-bindgen
 [tensorflow project]: https://github.com/tensorflow/tensorflow
 [TensorFlow Lite Swift API]: https://www.tensorflow.org/lite/guide/ios

--- a/build.rs
+++ b/build.rs
@@ -46,10 +46,10 @@ fn copy_or_overwrite<P: AsRef<Path> + Debug, Q: AsRef<Path> + Debug>(src: P, des
             ..fs_extra::dir::CopyOptions::new()
         };
         fs_extra::dir::copy(src_path, dest_path, &options)
-            .unwrap_or_else(|e| panic!("Cannot directory copy from {:?} to {:?}. Error: {}", src, dest, e));
+            .unwrap_or_else(|e| panic!("Cannot copy directory from {:?} to {:?}. Error: {}", src, dest, e));
     } else {
         std::fs::copy(src_path, dest_path)
-            .unwrap_or_else(|_| panic!("Cannot file copy from {:?} to {:?}", src, dest));
+            .unwrap_or_else(|e| panic!("Cannot copy file from {:?} to {:?}. Error: {}", src, dest, e));
     }
 }
 

--- a/build.rs
+++ b/build.rs
@@ -5,7 +5,7 @@ use std::fmt::Debug;
 use std::path::{Path, PathBuf};
 use std::time::Instant;
 
-const TF_BRANCH: &str = "r2.6";
+const TAG: &str = "v2.9.1";
 const TF_GIT_URL: &str = "https://github.com/tensorflow/tensorflow.git";
 
 fn target_os() -> String {
@@ -88,7 +88,7 @@ fn prepare_tensorflow_repo() -> PathBuf {
         git.arg("clone")
             .args(&["--depth", "1"])
             .arg("--shallow-submodules")
-            .args(&["--branch", TF_BRANCH])
+            .args(&["--branch", TAG])
             .arg("--single-branch")
             .arg(TF_GIT_URL)
             .arg(tgt_result.to_str().unwrap());

--- a/build.rs
+++ b/build.rs
@@ -351,8 +351,23 @@ fn generate_bindings(tf_src_path: PathBuf) {
 
 fn install_prebuilt(prebuilt_tflitec_path: &str, tf_src_path: &Path, lib_output_path: &PathBuf) {
     // Copy prebuilt library to given path
-    let prebuilt_tflitec_path = PathBuf::from(prebuilt_tflitec_path);
-    copy_or_overwrite(prebuilt_tflitec_path, lib_output_path);
+    {
+        let prebuilt_tflitec_path = PathBuf::from(prebuilt_tflitec_path);
+        // Copy .{so,dylib,dll,Framework} file
+        copy_or_overwrite(&prebuilt_tflitec_path, lib_output_path);
+
+        if target_os() == "windows" {
+            // Copy .lib file
+            let mut prebuilt_lib_path = prebuilt_tflitec_path;
+            prebuilt_lib_path.set_extension("lib");
+            if !prebuilt_lib_path.exists() {
+                panic!("A prebuilt windows .dll file must have .lib file under the same directory!")
+            }
+            let mut lib_file_path = lib_output_path.clone();
+            lib_file_path.set_extension("lib");
+            copy_or_overwrite(prebuilt_lib_path, lib_file_path);
+        }
+    }
 
     let header_dir = tf_src_path.join("tensorflow/lite/c");
     let header_download_hint_file = header_dir.join(".complete_header_download");

--- a/build.rs
+++ b/build.rs
@@ -2,11 +2,14 @@ extern crate bindgen;
 
 use std::env;
 use std::fmt::Debug;
+use std::io::Write;
 use std::path::{Path, PathBuf};
 use std::time::Instant;
 
 const TAG: &str = "v2.9.1";
 const TF_GIT_URL: &str = "https://github.com/tensorflow/tensorflow.git";
+const BAZEL_COPTS_ENV_VAR: &str = "TFLITEC_BAZEL_COPTS";
+const PREBUILT_PATH_ENV_VAR: &str = "TFLITEC_PREBUILT_PATH";
 
 fn target_os() -> String {
     env::var("CARGO_CFG_TARGET_OS").expect("Unable to get TARGET_OS")
@@ -37,23 +40,37 @@ fn copy_or_overwrite<P: AsRef<Path> + Debug, Q: AsRef<Path> + Debug>(src: P, des
             std::fs::remove_dir_all(&dest_path).expect("Cannot remove directory");
         }
     }
-    std::fs::copy(src_path, dest_path)
-        .unwrap_or_else(|_| panic!("Cannot copy from {:?} to {:?}", src, dest));
-}
-
-fn test_python_bin(python_bin_path: &str) -> bool {
-    if let Ok(status) = std::process::Command::new(python_bin_path)
-        .args(&["-c", "import numpy"])
-        .status()
-    {
-        status.success()
+    if src_path.is_dir() {
+        let options = fs_extra::dir::CopyOptions {
+            copy_inside: true,
+            ..fs_extra::dir::CopyOptions::new()
+        };
+        fs_extra::dir::copy(src_path, dest_path, &options)
+            .unwrap_or_else(|e| panic!("Cannot directory copy from {:?} to {:?}. Error: {}", src, dest, e));
     } else {
-        false
+        std::fs::copy(src_path, dest_path)
+            .unwrap_or_else(|_| panic!("Cannot file copy from {:?} to {:?}", src, dest));
     }
 }
 
+fn test_python_bin(python_bin_path: &str) -> bool {
+    println!("Testing Python at {}", python_bin_path);
+    let success = std::process::Command::new(python_bin_path)
+        .args(&["-c", "import numpy"])
+        .status()
+        .map(|s| s.success())
+        .unwrap_or_default();
+    if success {
+        println!("Using Python at {}", python_bin_path);
+    }
+    success
+}
+
 fn get_python_bin_path() -> Option<PathBuf> {
-    if let Ok(val) = std::env::var("PYTHON_BIN_PATH") {
+    if let Ok(val) = env::var("PYTHON_BIN_PATH") {
+        if !test_python_bin(&val) {
+            panic!("Given Python binary failed in test!")
+        }
         Some(PathBuf::from(val))
     } else {
         let bin = if target_os() == "windows" {
@@ -81,9 +98,12 @@ fn get_python_bin_path() -> Option<PathBuf> {
     }
 }
 
-fn prepare_tensorflow_repo() -> PathBuf {
-    let tgt_result = out_dir().join("tensorflow");
-    if !tgt_result.exists() {
+fn prepare_tensorflow_source(tf_src_path: &Path) {
+    let complete_clone_hint_file = tf_src_path.join(".complete_clone");
+    if !complete_clone_hint_file.exists() {
+        if tf_src_path.exists() {
+            std::fs::remove_dir_all(tf_src_path).expect("Cannot clean tf_src_path");
+        }
         let mut git = std::process::Command::new("git");
         git.arg("clone")
             .args(&["--depth", "1"])
@@ -91,24 +111,24 @@ fn prepare_tensorflow_repo() -> PathBuf {
             .args(&["--branch", TAG])
             .arg("--single-branch")
             .arg(TF_GIT_URL)
-            .arg(tgt_result.to_str().unwrap());
+            .arg(tf_src_path.to_str().unwrap());
         println!("Git clone started");
         let start = Instant::now();
         if !git.status().expect("Cannot execute `git clone`").success() {
             panic!("git clone failed");
         }
+        std::fs::File::create(complete_clone_hint_file).expect("Cannot create clone hint file!");
         println!("Clone took {:?}", Instant::now() - start);
     }
 
     #[cfg(feature = "xnnpack")]
     {
-        let root = std::path::PathBuf::from(std::env::var("CARGO_MANIFEST_DIR").unwrap());
+        let root = std::path::PathBuf::from(env::var("CARGO_MANIFEST_DIR").unwrap());
         let bazel_build_path = root.join("build-res/tflitec_with_xnnpack_BUILD.bazel");
-        let target = tgt_result.join("tensorflow/lite/c/tmp/BUILD");
+        let target = tf_src_path.join("tensorflow/lite/c/tmp/BUILD");
         std::fs::create_dir_all(target.parent().unwrap()).expect("Cannot create tmp directory");
         std::fs::copy(bazel_build_path, target).expect("Cannot copy temporary BUILD file");
     }
-    tgt_result
 }
 
 fn check_and_set_envs() {
@@ -156,9 +176,18 @@ fn check_and_set_envs() {
     }
 }
 
-fn build_tensorflow_with_bazel(tf_src_path: &str, config: &str) -> PathBuf {
+fn lib_output_path() -> PathBuf {
+    if target_os() != "ios" {
+        let ext = dll_extension();
+        let lib_prefix = dll_prefix();
+        out_dir().join(format!("{}tensorflowlite_c.{}", lib_prefix, ext))
+    } else {
+        out_dir().join("TensorFlowLiteC.framework")
+    }
+}
+
+fn build_tensorflow_with_bazel(tf_src_path: &str, config: &str, lib_output_path: &Path) {
     let target_os = target_os();
-    let lib_output_path_buf;
     let bazel_output_path_buf;
     let bazel_target;
     if target_os != "ios" {
@@ -179,7 +208,6 @@ fn build_tensorflow_with_bazel(tf_src_path: &str, config: &str) -> PathBuf {
         let lib_prefix = dll_prefix();
         bazel_output_path_buf = lib_out_dir.join(format!("{}tensorflowlite_c.{}", lib_prefix, ext));
         bazel_target = format!("//tensorflow/lite/c{}:tensorflowlite_c", sub_directory);
-        lib_output_path_buf = out_dir().join(format!("{}tensorflowlite_c.{}", lib_prefix, ext));
     } else {
         bazel_output_path_buf = PathBuf::from(tf_src_path)
             .join("bazel-bin")
@@ -188,7 +216,6 @@ fn build_tensorflow_with_bazel(tf_src_path: &str, config: &str) -> PathBuf {
             .join("ios")
             .join("TensorFlowLiteC_framework.zip");
         bazel_target = String::from("//tensorflow/lite/ios:TensorFlowLiteC_framework");
-        lib_output_path_buf = out_dir().join("TensorFlowLiteC.framework");
     };
 
     let python_bin_path = env::var("PYTHON_BIN_PATH").expect("Cannot read PYTHON_BIN_PATH");
@@ -221,7 +248,7 @@ fn build_tensorflow_with_bazel(tf_src_path: &str, config: &str) -> PathBuf {
         .arg(bazel_target)
         .current_dir(tf_src_path);
 
-    if let Ok(copts) = env::var("BAZEL_COPTS") {
+    if let Ok(copts) = env::var(BAZEL_COPTS_ENV_VAR) {
         let copts = copts.split_ascii_whitespace();
         for opt in copts {
             bazel.arg(format!("--copt={}", opt));
@@ -231,6 +258,7 @@ fn build_tensorflow_with_bazel(tf_src_path: &str, config: &str) -> PathBuf {
     if target_os == "ios" {
         bazel.args(&["--apple_bitcode=embedded", "--copt=-fembed-bitcode"]);
     }
+    println!("Bazel Build Command: {:?}", bazel);
     if !bazel.status().expect("Cannot execute bazel").success() {
         panic!("Cannot build TensorFlowLiteC");
     }
@@ -241,7 +269,7 @@ fn build_tensorflow_with_bazel(tf_src_path: &str, config: &str) -> PathBuf {
         )
     }
     if target_os != "ios" {
-        copy_or_overwrite(&bazel_output_path_buf, &lib_output_path_buf);
+        copy_or_overwrite(&bazel_output_path_buf, &lib_output_path);
         if target_os == "windows" {
             let mut bazel_output_winlib_path_buf = bazel_output_path_buf;
             bazel_output_winlib_path_buf.set_extension("dll.if.lib");
@@ -249,8 +277,8 @@ fn build_tensorflow_with_bazel(tf_src_path: &str, config: &str) -> PathBuf {
             copy_or_overwrite(bazel_output_winlib_path_buf, winlib_output_path_buf);
         }
     } else {
-        if lib_output_path_buf.exists() {
-            std::fs::remove_dir_all(&lib_output_path_buf).unwrap();
+        if lib_output_path.exists() {
+            std::fs::remove_dir_all(&lib_output_path).unwrap();
         }
         let mut unzip = std::process::Command::new("unzip");
         unzip.args(&[
@@ -261,7 +289,6 @@ fn build_tensorflow_with_bazel(tf_src_path: &str, config: &str) -> PathBuf {
         ]);
         unzip.status().expect("Cannot execute unzip");
     }
-    lib_output_path_buf
 }
 
 fn out_dir() -> PathBuf {
@@ -274,7 +301,7 @@ fn prepare_for_docsrs() {
     let bindings_path = out_dir().join("bindings.rs");
 
     let mut unzip = std::process::Command::new("unzip");
-    let root = std::path::PathBuf::from(std::env::var("CARGO_MANIFEST_DIR").unwrap());
+    let root = std::path::PathBuf::from(env::var("CARGO_MANIFEST_DIR").unwrap());
     unzip
         .arg(root.join("build-res/docsrs_res.zip"))
         .arg("-d")
@@ -290,11 +317,80 @@ fn prepare_for_docsrs() {
     }
 }
 
+fn generate_bindings(tf_src_path: PathBuf) {
+    let mut builder = bindgen::Builder::default().header(
+        tf_src_path
+            .join("tensorflow/lite/c/c_api.h")
+            .to_str()
+            .unwrap(),
+    );
+    if cfg!(feature = "xnnpack") {
+        builder = builder.header(
+            tf_src_path
+                .join("tensorflow/lite/delegates/xnnpack/xnnpack_delegate.h")
+                .to_str()
+                .unwrap(),
+        );
+    }
+
+    let bindings = builder
+        .clang_arg(format!("-I{}", tf_src_path.to_str().unwrap()))
+        // Tell cargo to invalidate the built crate whenever any of the
+        // included header files changed.
+        .parse_callbacks(Box::new(bindgen::CargoCallbacks))
+        // Finish the builder and generate the bindings.
+        .generate()
+        // Unwrap the Result and panic on failure.
+        .expect("Unable to generate bindings");
+
+    // Write the bindings to the $OUT_DIR/bindings.rs file.
+    bindings
+        .write_to_file(out_dir().join("bindings.rs"))
+        .expect("Couldn't write bindings!");
+}
+
+fn install_prebuilt(prebuilt_tflitec_path: &str, tf_src_path: &Path, lib_output_path: &PathBuf) {
+    // Copy prebuilt library to given path
+    let prebuilt_tflitec_path = PathBuf::from(prebuilt_tflitec_path);
+    copy_or_overwrite(prebuilt_tflitec_path, lib_output_path);
+
+    let header_dir = tf_src_path.join("tensorflow/lite/c");
+    let header_download_hint_file = header_dir.join(".complete_header_download");
+    if !header_download_hint_file.exists() {
+        // Download necessary header files from Github
+        std::fs::create_dir_all(header_dir).expect("Cannot generate header dir");
+        for path in [
+            "tensorflow/lite/c/c_api.h",
+            "tensorflow/lite/c/c_api_types.h",
+        ] {
+            let url = format!(
+                "https://raw.githubusercontent.com/tensorflow/tensorflow/{}/{}",
+                TAG, path
+            );
+            download_file(&url, &tf_src_path.join(path));
+        }
+        // Create hint file to skip download unnecessarily
+        std::fs::File::create(header_download_hint_file)
+            .expect("Cannot create header download hint file");
+    }
+}
+
+fn download_file(url: &str, path: &Path) {
+    let mut easy = curl::easy::Easy::new();
+    let output_file = std::fs::File::create(path).unwrap();
+    let mut writer = std::io::BufWriter::new(output_file);
+    easy.url(url).unwrap();
+    easy.write_function(move |data| Ok(writer.write(data).unwrap()))
+        .unwrap();
+    easy.perform().unwrap();
+}
+
 fn main() {
-    println!("cargo:rerun-if-env-changed=BAZEL_COPTS");
+    println!("cargo:rerun-if-env-changed={}", BAZEL_COPTS_ENV_VAR);
+    println!("cargo:rerun-if-env-changed={}", PREBUILT_PATH_ENV_VAR);
 
     let out_path = out_dir();
-    let os = env::var("CARGO_CFG_TARGET_OS").expect("Unable to get TARGET_OS");
+    let os = target_os();
     let arch = env::var("CARGO_CFG_TARGET_ARCH").expect("Unable to get TARGET_ARCH");
     let arch = match arch.as_str() {
         "aarch64" => String::from("arm64"),
@@ -314,47 +410,32 @@ fn main() {
         println!("cargo:rustc-link-search=framework={}", out_path.display());
         println!("cargo:rustc-link-lib=framework=TensorFlowLiteC");
     }
-    if std::env::var("DOCS_RS") == Ok(String::from("1")) {
+    if env::var("DOCS_RS") == Ok(String::from("1")) {
         // docs.rs cannot access to network, use resource files
         prepare_for_docsrs();
     } else {
-        let config = if os == "android" || os == "ios" {
-            format!("{}_{}", os, arch)
-        } else {
-            os
-        };
-        let tf_src_path = prepare_tensorflow_repo();
-        check_and_set_envs();
-        build_tensorflow_with_bazel(tf_src_path.to_str().unwrap(), config.as_str());
+        let tf_src_path = out_path.join(format!("tensorflow_{}", TAG));
+        let lib_output_path = lib_output_path();
 
-        let mut builder = bindgen::Builder::default().header(
-            tf_src_path
-                .join("tensorflow/lite/c/c_api.h")
-                .to_str()
-                .unwrap(),
-        );
-        if cfg!(feature = "xnnpack") {
-            builder = builder.header(
-                tf_src_path
-                    .join("tensorflow/lite/delegates/xnnpack/xnnpack_delegate.h")
-                    .to_str()
-                    .unwrap(),
+        if let Ok(prebuilt_tflitec_path) = env::var(PREBUILT_PATH_ENV_VAR) {
+            install_prebuilt(&prebuilt_tflitec_path, &tf_src_path, &lib_output_path);
+        } else {
+            // Build from source
+            let config = if os == "android" || os == "ios" {
+                format!("{}_{}", os, arch)
+            } else {
+                os
+            };
+            prepare_tensorflow_source(tf_src_path.as_path());
+            check_and_set_envs();
+            build_tensorflow_with_bazel(
+                tf_src_path.to_str().unwrap(),
+                config.as_str(),
+                lib_output_path.as_path(),
             );
         }
 
-        let bindings = builder
-            .clang_arg(format!("-I{}", tf_src_path.to_str().unwrap()))
-            // Tell cargo to invalidate the built crate whenever any of the
-            // included header files changed.
-            .parse_callbacks(Box::new(bindgen::CargoCallbacks))
-            // Finish the builder and generate the bindings.
-            .generate()
-            // Unwrap the Result and panic on failure.
-            .expect("Unable to generate bindings");
-
-        // Write the bindings to the $OUT_DIR/bindings.rs file.
-        bindings
-            .write_to_file(out_path.join("bindings.rs"))
-            .expect("Couldn't write bindings!");
+        // Generate bindings using headers
+        generate_bindings(tf_src_path);
     }
 }

--- a/build.rs
+++ b/build.rs
@@ -82,7 +82,7 @@ fn get_target_dependent_env_var(var: &str) -> Option<String> {
 fn test_python_bin(python_bin_path: &str) -> bool {
     println!("Testing Python at {}", python_bin_path);
     let success = std::process::Command::new(python_bin_path)
-        .args(&["-c", "import numpy"])
+        .args(&["-c", "import numpy, importlib.util"])
         .status()
         .map(|s| s.success())
         .unwrap_or_default();
@@ -109,6 +109,7 @@ fn get_python_bin_path() -> Option<PathBuf> {
                 if test_python_bin(path) {
                     return Some(PathBuf::from(path));
                 }
+                println!("cargo:warning={:?} failed import test", path)
             }
         }
         if let Ok(x) = std::process::Command::new(bin).arg("python").output() {
@@ -116,6 +117,7 @@ fn get_python_bin_path() -> Option<PathBuf> {
                 if test_python_bin(path) {
                     return Some(PathBuf::from(path));
                 }
+                println!("cargo:warning={:?} failed import test", path)
             }
             None
         } else {
@@ -467,8 +469,8 @@ fn main() {
             } else {
                 os
             };
-            prepare_tensorflow_source(tf_src_path.as_path());
             check_and_set_envs();
+            prepare_tensorflow_source(tf_src_path.as_path());
             build_tensorflow_with_bazel(
                 tf_src_path.to_str().unwrap(),
                 config.as_str(),


### PR DESCRIPTION
This PR implement prebuilt library support during build step. This makes compilation much more faster, because it does not build `libtensorflowlite_c`. Usage is documented in the README.